### PR TITLE
Compliance with the D-PDU API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dpdu-api-types"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Ashcon Mohseninia <ashconm@outlook.com>", "RichardWGNR <171420035+RichardWGNR@users.noreply.github.com>"]
 edition = "2021"
 description = "An implementation of the core D-PDU (ISO22900-2) library in Rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dpdu-api-types"
 version = "0.9.1"
 authors = ["Ashcon Mohseninia <ashconm@outlook.com>", "RichardWGNR <171420035+RichardWGNR@users.noreply.github.com>"]
-edition = "2021"
+edition = "2024"
 description = "An implementation of the core D-PDU (ISO22900-2) library in Rust"
 license = "MIT"
 repository = "https://github.com/RichardWGNR/dpdu-api-types"

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -1,5 +1,4 @@
-
-#[repr(C)]
+#[repr(u32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 /// Item type values
 pub enum PduIt {
@@ -43,7 +42,7 @@ pub enum PduIt {
     EntityStatus = 0x1803
 }
 
-#[repr(C)]
+#[repr(u32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 /// Communication primitive (ComParam) type
 pub enum PduCopt {
@@ -62,7 +61,7 @@ pub enum PduCopt {
     RestoreParam = 0x8006
 }
 
-#[repr(C)]
+#[repr(u32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 /// Object type
 pub enum PduObjt {
@@ -80,7 +79,7 @@ pub enum PduObjt {
     Resource = 0x8026
 }
 
-#[repr(C)]
+#[repr(u32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 /// Status codes
 pub enum PduStatus {
@@ -110,7 +109,7 @@ pub enum PduStatus {
     ModstAvail = 0x8063
 }
 
-#[repr(C)]
+#[repr(u32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 /// Information events
 pub enum PduInfo {
@@ -122,7 +121,7 @@ pub enum PduInfo {
     ComParamChange = 0x8072
 }
 
-#[repr(C)]
+#[repr(u32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 /// Event callback
 pub enum PduEvtData {
@@ -132,7 +131,7 @@ pub enum PduEvtData {
     Lost = 0x0802
 }
 
-#[repr(C)]
+#[repr(u32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 /// Filter type
 pub enum PduFilter {
@@ -146,7 +145,7 @@ pub enum PduFilter {
     BlockUUDT = 0x00000012
 }
 
-#[repr(C)]
+#[repr(u32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 /// IOCTL queue mode
 pub enum PduQueueMode {
@@ -161,7 +160,7 @@ pub enum PduQueueMode {
     Circular = 0x00000002
 }
 
-#[repr(C)]
+#[repr(u32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 /// Function return values
 pub enum PduError {
@@ -257,7 +256,7 @@ pub enum PduError {
     DoIPResponseTimeout = 0x000000BC
 }
 
-#[repr(C)]
+#[repr(u32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 /// Function error events (Used in asynchronous situations)
 pub enum PduErrorEvt {
@@ -285,7 +284,7 @@ pub enum PduErrorEvt {
     InitError = 0x00000108
 }
 
-#[repr(C)]
+#[repr(u32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 /// ComParam data type
 pub enum PduPt {
@@ -309,7 +308,7 @@ pub enum PduPt {
     LongField = 0x00000109
 }
 
-#[repr(C)]
+#[repr(u32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 /// ComParam data class
 pub enum PduPc {
@@ -329,7 +328,7 @@ pub enum PduPc {
     TesterPresent = 7
 }
 
-#[repr(C)]
+#[repr(u32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 /// ComParam struct type
 pub enum PduCpst {
@@ -339,7 +338,7 @@ pub enum PduCpst {
     AccessTiming = 0x00000002,
 }
 
-#[repr(u32)]
+#[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 /// Vehicle preselection mode
 pub enum VidPreselectMode {
@@ -351,7 +350,7 @@ pub enum VidPreselectMode {
     EID = 2
 }
 
-#[repr(u32)]
+#[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 /// DoIP Combination mode
 pub enum CombinationMode {

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -12,7 +12,7 @@ pub enum PduIt {
     IoFilter = 0x1003,
     /// IOCTL event queue priority
     IoEventQueueProperty = 0x1004,
-    /// Resource status 
+    /// Resource status
     RscStatus = 0x1100,
     /// Communication parameter (ComParam)
     Param = 0x1200,
@@ -39,7 +39,7 @@ pub enum PduIt {
     /// DoIP entity addressing
     EntityAddress = 0x1802,
     /// DoIP entity status
-    EntityStatus = 0x1803
+    EntityStatus = 0x1803,
 }
 
 #[repr(u32)]
@@ -58,7 +58,7 @@ pub enum PduCopt {
     Delay = 0x8005,
     /// Opposite of [PduCopt::UpdateParam], copies active com param from logical communication
     /// link to a working buffer
-    RestoreParam = 0x8006
+    RestoreParam = 0x8006,
 }
 
 #[repr(u32)]
@@ -76,7 +76,7 @@ pub enum PduObjt {
     /// Pin type object
     PinType = 0x8025,
     /// resource object
-    Resource = 0x8026
+    Resource = 0x8026,
 }
 
 #[repr(u32)]
@@ -106,7 +106,7 @@ pub enum PduStatus {
     /// Vehicle communication interface is unavailable for connection
     ModstNotAvail = 0x8062,
     /// Vehicle communication interface is available for connection
-    ModstAvail = 0x8063
+    ModstAvail = 0x8063,
 }
 
 #[repr(u32)]
@@ -118,7 +118,7 @@ pub enum PduInfo {
     /// A change has occurred with the lock status on a shared resource
     ResourceLockChange = 0x8071,
     /// A communication parameter on a logical link has been changed
-    ComParamChange = 0x8072
+    ComParamChange = 0x8072,
 }
 
 #[repr(u32)]
@@ -128,7 +128,7 @@ pub enum PduEvtData {
     /// There is event data available to read by the application
     Available = 0x801,
     /// The ComLogicalLink has lost event data due to a buffer overrun
-    Lost = 0x0802
+    Lost = 0x0802,
 }
 
 #[repr(u32)]
@@ -142,7 +142,7 @@ pub enum PduFilter {
     /// Matches messages go into the receive queue that are UUDT only (For ISO1765)
     PassUUDT = 0x00000011,
     /// Matches messages stay out of the receive queue that are UUDT only (For ISO1765)
-    BlockUUDT = 0x00000012
+    BlockUUDT = 0x00000012,
 }
 
 #[repr(u32)]
@@ -157,7 +157,7 @@ pub enum PduQueueMode {
     Limited = 0x00000001,
     /// Attempt to allocate a fixed buffer size for events coming into the receive queue. Events overwrite
     /// stored events if the buffer is full (Like a circular buffer)
-    Circular = 0x00000002
+    Circular = 0x00000002,
 }
 
 #[repr(u32)]
@@ -253,7 +253,7 @@ pub enum PduError {
     /// DoIP Routing activation failed - Timeout waiting for activation response
     DoIPRoutingActivationResponseTimeout = 0x000000BB,
     /// DoIP general timeout
-    DoIPResponseTimeout = 0x000000BC
+    DoIPResponseTimeout = 0x000000BC,
 }
 
 #[repr(u32)]
@@ -281,7 +281,7 @@ pub enum PduErrorEvt {
     /// MVCI hardware fault
     VCIHardwareFault = 0x00000107,
     /// Protocol initialization error
-    InitError = 0x00000108
+    InitError = 0x00000108,
 }
 
 #[repr(u32)]
@@ -305,7 +305,7 @@ pub enum PduPt {
     /// Structure
     StructField = 0x000000108,
     /// Array of 32bit values
-    LongField = 0x00000109
+    LongField = 0x00000109,
 }
 
 #[repr(u32)]
@@ -322,10 +322,10 @@ pub enum PduPc {
     ErrHdl = 4,
     /// BusType specific ComParam
     BusType = 5,
-    /// 
+    ///
     UniqueId = 6,
     /// Tester present ComParam
-    TesterPresent = 7
+    TesterPresent = 7,
 }
 
 #[repr(u32)]
@@ -347,7 +347,7 @@ pub enum VidPreselectMode {
     /// DoIP with given VIN
     VIN = 1,
     /// DoIP with given EID
-    EID = 2
+    EID = 2,
 }
 
 #[repr(u8)]
@@ -361,7 +361,7 @@ pub enum CombinationMode {
     /// Combine common GroupID
     Group = 2,
     /// Combine all
-    All = 3
+    All = 3,
 }
 
 #[repr(u8)]
@@ -377,5 +377,5 @@ pub enum TimingSet {
     /// Normal timing set
     Normal = 4,
     /// Extended timing set
-    Extended = 0xFF
+    Extended = 0xFF,
 }

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -2,50 +2,44 @@ use std::ffi::c_void;
 
 use crate::*;
 
-
-
 /// Constructs and initializes the PDU API library
-/// 
+///
 /// ## Parameters
 /// * option_str - A list of attributes and values specific to D-PDU API
 /// * p_api_tag - Application defined tag value for callbacks
-pub type PduConstructFn = extern "system" fn(
-    option_str: *mut u8, 
-    p_api_tag: *mut c_void
-) -> PduError;
+pub type PduConstructFn =
+    extern "system" fn(option_str: *mut u8, p_api_tag: *mut c_void) -> PduError;
 
 /// Closes all open communication channels and destructs the PDU API library
 pub type PduDestructFn = extern "system" fn() -> PduError;
 
 /// Performs generic IOCTL calls on a MVCI or ComLogicalLink
-/// 
+///
 /// ## Parameters
 /// * h_mod - Handle of MVCI module
 /// * h_cll - Handle of the ComLogicalLink
 /// * ioctl_commanded_id - IO Command to send to ComLogicalLink
 /// * p_input_data - Pointer to input data item (Null if not required)
 /// * p_output_data - Pointer to output data item (Null if not required)
-/// 
+///
 pub type PduIoctlFn = extern "system" fn(
     h_mod: u32,
     h_cll: u32,
     ioctl_commanded_id: u32,
     p_input_data: *mut PduDataItem,
-    p_output_data: *mut *mut PduDataItem
+    p_output_data: *mut *mut PduDataItem,
 ) -> PduError;
 
 /// Gets version information from MVCI module
-/// 
+///
 /// ## Parameters
 /// * h_mod - Handle of the MVCI module
 /// * p_version_data - Output pointer for the destination of the version data
-pub type PduGetVersionFn = extern "system" fn(
-    h_mod: u32,
-    p_version_data: *mut VersionData
-) -> PduError;
+pub type PduGetVersionFn =
+    extern "system" fn(h_mod: u32, p_version_data: *mut VersionData) -> PduError;
 
 /// Gets runtime information from either a MVCI module, ComLogicalLink or ComPrimitive
-/// 
+///
 /// ## Parameters
 /// * h_mod - Handle of the MVCI module
 /// * h_cll - Handle of the ComLogicalLink
@@ -59,7 +53,7 @@ pub type PduGetStatusFn = extern "system" fn(
     h_cop: u32,
     p_status_code: *mut PduStatus,
     p_timestamp: *mut u32,
-    p_extra_info: *mut u32
+    p_extra_info: *mut u32,
 ) -> PduError;
 
 /// Gets the last runtime error from the MVCI module or ComLogicalLink
@@ -78,19 +72,18 @@ pub type PduGetLastErrorFn = extern "system" fn(
     p_error_code: *mut PduErrorEvt,
     ph_cop: *mut u32,
     p_timestamp: *mut u32,
-    p_extra_error_info: *mut u32
+    p_extra_error_info: *mut u32,
 ) -> PduError;
 
 /// Obtains resource status information from the PDU API
-/// 
+///
 /// ## Parameters
 /// * p_resource_status - Pointer to store the status of the requested resource IDs
-pub type PduGetResourceStatusFn = extern "system" fn(
-    p_resource_status: *mut RscStatusItem
-) -> PduError;
+pub type PduGetResourceStatusFn =
+    extern "system" fn(p_resource_status: *mut RscStatusItem) -> PduError;
 
 /// Creates a ComLogicalLink for a given resource ID
-/// 
+///
 /// ## Parameters
 /// * h_mod - Handle of the MVCI module
 /// * p_rsc_data - Pointer to resource data objects
@@ -104,65 +97,49 @@ pub type PduCreateComLogicalLinkFn = extern "system" fn(
     resource_id: u32,
     p_cll_tag: *mut c_void,
     ph_cll: *mut u32,
-    p_cll_create_flag: *mut FlagData
+    p_cll_create_flag: *mut FlagData,
 ) -> PduError;
 
 /// Destroys a given ComLogicalLink
-/// 
+///
 /// ## Parameters
 /// * h_mod - Handle of the MVCI module
 /// * h_cll - Handle of the ComLogicalLink to destroy
-pub type PduDestroyComLogicalLinkFn = extern "system" fn(
-    h_mod: u32,
-    h_cll: u32
-) -> PduError;
+pub type PduDestroyComLogicalLinkFn = extern "system" fn(h_mod: u32, h_cll: u32) -> PduError;
 
 /// Connects a ComLogicalLink to a vehicle interface
-/// 
+///
 /// ## Parameters
 /// * h_mod - Handle of the MVCI module
 /// * h_cll - Handle of the ComLogicalLink to connect
-pub type PduConnectFn = extern "system" fn(
-    h_mod: u32,
-    h_cll: u32
-) -> PduError;
+pub type PduConnectFn = extern "system" fn(h_mod: u32, h_cll: u32) -> PduError;
 
 /// Disconnects a ComLogicalLink from a vehicle interface
-/// 
+///
 /// ## Parameters
 /// * h_mod - Handle of the MVCI module
 /// * h_cll - Handle of the ComLogicalLink to disconnect
-pub type PduDisconnectFn = extern "system" fn(
-    h_mod: u32,
-    h_cll: u32
-) -> PduError;
+pub type PduDisconnectFn = extern "system" fn(h_mod: u32, h_cll: u32) -> PduError;
 
 /// Locks a physical resource so that a ComLogicalLink has exclusive access to it
-/// 
+///
 /// ## Parameters
 /// * h_mod - Handle of the MVCI module
 /// * h_cll - Handle of the ComLogicalLink to be granted exclusive access
 /// * lock_mask - Bit encoded mask to request for locking
-pub type PduLockResourceFn = extern "system" fn(
-    h_mod: u32,
-    h_cll: u32,
-    lock_mask: u32
-) -> PduError;
+pub type PduLockResourceFn = extern "system" fn(h_mod: u32, h_cll: u32, lock_mask: u32) -> PduError;
 
 /// Unlocks a physical resource from a ComLogicalLink that has exclusive access to it
-/// 
+///
 /// ## Parameters
 /// * h_mod - Handle of the MVCI module
 /// * h_cll - Handle of the ComLogicalLink to unlock the resource from
 /// * lock_mask - Bit encoded mask to request for release
-pub type PduUnlockResourceFn = extern "system" fn(
-    h_mod: u32,
-    h_cll: u32,
-    lock_mask: u32
-) -> PduError;
+pub type PduUnlockResourceFn =
+    extern "system" fn(h_mod: u32, h_cll: u32, lock_mask: u32) -> PduError;
 
 /// Obtains a communication or bus ComParam out of the MVCIs working buffer of a ComLogicalLink
-/// 
+///
 /// ## Parameters
 /// * h_mod - Handle of the MVCI module
 /// * h_cll - Handle of the ComLogicalLink
@@ -172,7 +149,7 @@ pub type PduGetComParamFn = extern "system" fn(
     h_mod: u32,
     h_cll: u32,
     param_id: u32,
-    p_param_item: *mut *mut ParamItem
+    p_param_item: *mut *mut ParamItem,
 ) -> PduError;
 
 /// Sets a com param on a ComLogicalLink
@@ -181,14 +158,11 @@ pub type PduGetComParamFn = extern "system" fn(
 /// * h_mod - Handle of the MVCI module
 /// * h_cll - Handle of the ComLogicalLink to set the param on
 /// * p_param_item - Pointer to a ComParams to set
-pub type PduSetComParamFn = extern "system" fn(
-    h_mod: u32,
-    h_cll: u32,
-    p_param_item: *mut ParamItem
-) -> PduError;
+pub type PduSetComParamFn =
+    extern "system" fn(h_mod: u32, h_cll: u32, p_param_item: *mut ParamItem) -> PduError;
 
 /// Creates and starts a ComPrimitive
-/// 
+///
 /// ## Parameters
 /// * h_mod - Handle of the MVCI module
 /// * h_cll - Handle of the ComLogicalLink to start the ComPrimitive on
@@ -205,55 +179,44 @@ pub type PduStartComPrimitiveFn = extern "system" fn(
     p_cop_data: *mut u8,
     p_cop_ctrl_data: *mut CopCtrlData,
     p_cop_tag: *mut c_void,
-    ph_cop: *mut u32
+    ph_cop: *mut u32,
 ) -> PduError;
 
 /// Cancels and stops a ComPrimitive
-/// 
+///
 /// ## Parameters
 /// * h_mod - Handle of the MVCI module
 /// * h_cll - Handle of the ComLogicalLink
 /// * h_cop - Handle of the ComPrimitive
-pub type PduCancelComPrimitiveFn = extern "system" fn(
-    h_mod: u32,
-    h_cll: u32,
-    h_cop: u32
-) -> PduError;
+pub type PduCancelComPrimitiveFn =
+    extern "system" fn(h_mod: u32, h_cll: u32, h_cop: u32) -> PduError;
 
 /// Retrieves event data for a given event source
-/// 
+///
 /// ## Parameter
 /// * h_mod - Handle of the MVCI module
 /// * h_cll - Handle of the ComLogicalLink
 /// * p_event_item - Pointer to store the event item
-pub type PduGetEventItemFn = extern "system" fn(
-    h_mod: u32,
-    h_cll: u32,
-    p_event_item: *mut *mut EventItem
-) -> PduError;
+pub type PduGetEventItemFn =
+    extern "system" fn(h_mod: u32, h_cll: u32, p_event_item: *mut *mut EventItem) -> PduError;
 
 /// Destroys a given item
-/// 
+///
 /// ## Parameters
 /// * p_item - Pointer to item to be destroyed
-pub type PduDestroyItemFn = extern "system" fn(
-    p_item: *mut PduItem
-) -> PduError;
+pub type PduDestroyItemFn = extern "system" fn(p_item: *mut PduItem) -> PduError;
 
 /// Registers a callback function
-/// 
+///
 /// ## Parameters
 /// * h_mod - Handle of the MVCI module
 /// * h_cll - Handle of the ComLogicalLink
 /// * callback_fn - Callback function (null to deregister callback)
-pub type PduRegisterCallbackFn = extern "system" fn(
-    h_mod: u32,
-    h_cll: u32,
-    callback_fn: EventCallbackFn
-) -> PduError;
+pub type PduRegisterCallbackFn =
+    extern "system" fn(h_mod: u32, h_cll: u32, callback_fn: EventCallbackFn) -> PduError;
 
 /// Gets the Item ID of a given item
-/// 
+///
 /// ## Parameters
 /// * pdu_object_type - Type of object
 /// * p_short_name - Short name of the object
@@ -261,20 +224,17 @@ pub type PduRegisterCallbackFn = extern "system" fn(
 pub type PduGetObjectIdFn = extern "system" fn(
     pdu_object_type: PduObjt,
     p_short_name: *mut u8,
-    p_pdu_object_id: *mut u32
+    p_pdu_object_id: *mut u32,
 ) -> PduError;
-
 
 /// Object module information
-/// 
+///
 /// ## Parameters
 /// * p_module_id_list - Pointer for storing the pointer of the module information list
-pub type PduGetModuleIdsFn = extern "system" fn(
-    p_module_id_list: *mut *mut ModuleItem
-) -> PduError;
+pub type PduGetModuleIdsFn = extern "system" fn(p_module_id_list: *mut *mut ModuleItem) -> PduError;
 
 /// Get a list of resource IDs
-/// 
+///
 /// ## Parameters
 /// * h_mod - Handle of the MVCI module
 /// * p_resource_id_data - Pointer to store resource ID data
@@ -282,11 +242,11 @@ pub type PduGetModuleIdsFn = extern "system" fn(
 pub type PduGetResourceIdsFn = extern "system" fn(
     h_mod: u32,
     p_resource_id_data: *mut RscData,
-    p_resource_id_list: *mut *mut RscIdItem
+    p_resource_id_list: *mut *mut RscIdItem,
 ) -> PduError;
 
 /// Gets a list of conflicting resources
-/// 
+///
 /// ## Parameters
 /// * resource_id - Resource ID to check for conflicts
 /// * p_input_module_list - Pointer to module to check for conflicts
@@ -294,11 +254,11 @@ pub type PduGetResourceIdsFn = extern "system" fn(
 pub type PduGetConflictingResourcesFn = extern "system" fn(
     resource_id: u32,
     p_input_module_list: *mut ModuleItem,
-    p_output_conflict_list: *mut *mut RscConflictItem
+    p_output_conflict_list: *mut *mut RscConflictItem,
 ) -> PduError;
 
 /// Gets a list of unique response IDs from a ComLogicalLink
-/// 
+///
 /// ## Parameters
 /// * h_mod - Handle of the MVCI module
 /// * h_cll - Handle of the ComLogicalLink
@@ -306,11 +266,11 @@ pub type PduGetConflictingResourcesFn = extern "system" fn(
 pub type PduGetUniqueRespIdTableFn = extern "system" fn(
     h_mod: u32,
     h_cll: u32,
-    p_unique_resp_id_table: *mut *mut UniqueRespIdTableItem
+    p_unique_resp_id_table: *mut *mut UniqueRespIdTableItem,
 ) -> PduError;
 
 /// Sets a unique response ID table for the ComLogicalLink
-/// 
+///
 /// ## Parameters
 /// * h_mod - Handle of the MVCI module
 /// * h_cll - Handle of the ComLogicalLink
@@ -318,30 +278,23 @@ pub type PduGetUniqueRespIdTableFn = extern "system" fn(
 pub type PduSetUniqueRespIdTableFn = extern "system" fn(
     h_mod: u32,
     h_cll: u32,
-    p_unique_resp_id_table: *mut UniqueRespIdTableItem
+    p_unique_resp_id_table: *mut UniqueRespIdTableItem,
 ) -> PduError;
 
 /// Determines if a MVCI module is available to connect
-/// 
+///
 /// ## Parameters
 /// * h_mod - Handle of the MVCI module to try and connect
-pub type PduModuleConnectFn = extern "system" fn(
-    h_mod: u32
-) -> PduError;
+pub type PduModuleConnectFn = extern "system" fn(h_mod: u32) -> PduError;
 
 /// Tries to close all communication channels of a MVCI module
-/// 
+///
 /// ## Parameters
 /// * h_mod - Handle of the MVCI module to disconnect
-pub type PduModuleDisconnectFn = extern "system" fn(
-    h_mod: u32
-) -> PduError;
+pub type PduModuleDisconnectFn = extern "system" fn(h_mod: u32) -> PduError;
 
 /// Obtains the current hardware clock of the MVCI module
-/// 
+///
 /// ## Parameters
 /// * p_timestamp - Pointer to store timestamp in microseconds
-pub type PduGetTimestampFn = extern "system" fn(
-    h_mod: u32,
-    p_timestamp: *mut u32
-) -> PduError;
+pub type PduGetTimestampFn = extern "system" fn(h_mod: u32, p_timestamp: *mut u32) -> PduError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,20 +11,20 @@
 )]
 
 //! A core implementation of the D-PDU API (ISO 22900-2).
-//! 
+//!
 //! This crate just provides the type definitions in order to use the API with Rust code.
-//! 
+//!
 //! For a crate that actually uses this API, you can check the [ecu_diagnostics crate](https://docs.rs/ecu_diagnostics/latest/ecu_diagnostics/)
 //!
 //! NOTE: To match the rust naming convention, enums and structure names have been slightly renamed.
-mod structures;
 mod enums;
 mod functions;
+mod structures;
 
 use std::ffi::c_void;
 
-pub use functions::*;
 pub use enums::*;
+pub use functions::*;
 pub use structures::*;
 
 /// Undefined ID value
@@ -33,12 +33,11 @@ pub const PDU_ID_UNDEF: u32 = 0xFFFFFFFE;
 /// Undefined handle value
 pub const PDU_HANDLE_UNDEF: u32 = 0xFFFFFFFF;
 
-
 /// PDU Event callback function type
 pub type EventCallbackFn = unsafe extern "system" fn(
-    event_type: PduEvtData, 
-    h_mod: u32, 
+    event_type: PduEvtData,
+    h_mod: u32,
     h_cll: u32,
-    p_cll_tag: *mut c_void, 
-    p_api_tag: *mut c_void
+    p_cll_tag: *mut c_void,
+    p_api_tag: *mut c_void,
 );

--- a/src/structures.rs
+++ b/src/structures.rs
@@ -1,14 +1,16 @@
 use std::ffi::c_void;
 
-use crate::{PduIt, PduFilter, PduQueueMode, VidPreselectMode, CombinationMode, PduPt, PduPc, PduStatus, PduInfo, PduErrorEvt, PduCpst, TimingSet};
-
+use crate::{
+    CombinationMode, PduCpst, PduErrorEvt, PduFilter, PduInfo, PduIt, PduPc, PduPt, PduQueueMode,
+    PduStatus, TimingSet, VidPreselectMode,
+};
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 /// Generic structure containing item type
 pub struct PduItem {
     /// Item type
-    pub item_type: PduIt
+    pub item_type: PduIt,
 }
 
 #[repr(C)]
@@ -18,7 +20,7 @@ pub struct PduDataItem {
     /// IOCTL Item type
     pub item_type: PduIt,
     /// IOCTL data structure pointer
-    pub p_data: *mut c_void
+    pub p_data: *mut c_void,
 }
 
 #[repr(C)]
@@ -28,7 +30,7 @@ pub struct IoProgVoltageData {
     /// Programming voltage (mV)
     pub prog_voltage_mv: u32,
     /// Pin number on connector
-    pub pin_on_dlc: u32
+    pub pin_on_dlc: u32,
 }
 
 #[repr(C)]
@@ -38,12 +40,15 @@ pub struct IoByteArrayData {
     /// Data size in bytes
     pub data_size: u32,
     /// Pointer to data
-    pub p_data: *mut u8 
+    pub p_data: *mut u8,
 }
 
 impl From<&mut [u8]> for IoByteArrayData {
     fn from(x: &mut [u8]) -> Self {
-        IoByteArrayData { data_size: x.len() as u32, p_data: x.as_mut_ptr() }
+        IoByteArrayData {
+            data_size: x.len() as u32,
+            p_data: x.as_mut_ptr(),
+        }
     }
 }
 
@@ -54,15 +59,15 @@ pub struct IoFilter {
     /// Number of IoFilterData structures
     /// by p_filter_data pointer.
     pub num_filter_entries: u32,
-    
+
     /// Pointer to the first IoFilterData structure
-    pub p_filter_data: *mut IoFilterData
+    pub p_filter_data: *mut IoFilterData,
 }
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 /// IOCTL Filter data structure
-/// 
+///
 /// MASK & RAW == PATTERN
 pub struct IoFilterData {
     /// Filter type
@@ -74,7 +79,7 @@ pub struct IoFilterData {
     /// Mask message
     pub filter_mask_msg: [u8; 12],
     /// Pattern message
-    pub filter_pattern_msg: [u8; 12]
+    pub filter_pattern_msg: [u8; 12],
 }
 
 #[repr(C)]
@@ -84,12 +89,12 @@ pub struct IoEventQueuePropertyData {
     /// Max size of the event queue
     pub queue_size: u32,
     /// Queue mode
-    pub queue_mode: PduQueueMode
+    pub queue_mode: PduQueueMode,
 }
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-/// IOCTL Vehicle ID request 
+/// IOCTL Vehicle ID request
 pub struct VehicleIdRequest {
     /// Preselection mode
     pub preselection_mode: VidPreselectMode,
@@ -102,7 +107,7 @@ pub struct VehicleIdRequest {
     /// Number of broadcast / multicast addresses found in [VehicleIdRequest::destination_addresses] array
     pub num_destination_addresses: u32,
     /// Pointer to array of IP addresses
-    pub destination_addresses: *mut IpAddrInfo
+    pub destination_addresses: *mut IpAddrInfo,
 }
 
 #[repr(C)]
@@ -112,7 +117,7 @@ pub struct IpAddrInfo {
     /// IP version 4 = Ipv4, 6 = Ipv6
     pub ip_version: u32,
     /// Pointer to broadcast address (4 bytes for Ipv4, 16 bytes for Ipv6)
-    pub p_address: *mut u8
+    pub p_address: *mut u8,
 }
 
 #[repr(C)]
@@ -122,7 +127,7 @@ pub struct EthSwitchState {
     /// Sense state - 0 = pin off, 1 = pin on
     pub eth_sense_state: u32,
     /// Pin number for ethernet activation
-    pub eth_act_pin_num: u32
+    pub eth_act_pin_num: u32,
 }
 
 #[repr(C)]
@@ -134,7 +139,7 @@ pub struct RscStatusData {
     /// Number of entries
     pub num_entries: u32,
     /// Pointer to array of entries
-    pub p_resource_status_data: *mut RscStatusItem
+    pub p_resource_status_data: *mut RscStatusItem,
 }
 
 #[repr(C)]
@@ -146,7 +151,7 @@ pub struct RscStatusItem {
     /// Resource ID
     pub resource_id: u32,
     /// Resource information status
-    pub resource_status: u32
+    pub resource_status: u32,
 }
 
 #[repr(C)]
@@ -162,7 +167,7 @@ pub struct ParamItem {
     /// Com param class type
     pub com_param_class: PduPc,
     /// Pointer to data of ComParam (of type specified in [ParamItem::com_param_class])
-    pub p_com_param_data: *mut c_void
+    pub p_com_param_data: *mut c_void,
 }
 
 #[repr(C)]
@@ -174,7 +179,7 @@ pub struct ModuleItem {
     /// Number of entries in [ModuleItem::p_module_data]
     pub num_entries: u32,
     /// Pointer to array of [ModuleData]
-    pub p_module_data: *mut ModuleData
+    pub p_module_data: *mut ModuleData,
 }
 
 #[repr(C)]
@@ -190,7 +195,7 @@ pub struct ModuleData {
     /// Null terminated string pointer of any additional info
     pub vendor_additional_info: *mut u8,
     /// Module status
-    pub status: PduStatus
+    pub status: PduStatus,
 }
 
 #[repr(C)]
@@ -202,7 +207,7 @@ pub struct RscIdItem {
     /// Number of entries in [RscIdItem::p_id_item_data]
     pub num_modules: u32,
     /// Pointer to array of [RscIdItemData]
-    pub p_id_item_data: *mut RscIdItemData
+    pub p_id_item_data: *mut RscIdItemData,
 }
 
 #[repr(C)]
@@ -214,7 +219,7 @@ pub struct RscIdItemData {
     /// Number of IDs
     pub num_ids: u32,
     /// Pointer to list of resource IDs
-    pub p_resource_id_array: *mut u32
+    pub p_resource_id_array: *mut u32,
 }
 
 #[repr(C)]
@@ -228,7 +233,7 @@ pub struct RscData {
     /// Number of items in [RscData::p_dlc_pin_data]
     pub num_pin_data: u32,
     /// Pointer to array of [PinData]
-    pub p_dlc_pin_data: *mut PinData
+    pub p_dlc_pin_data: *mut PinData,
 }
 
 #[repr(C)]
@@ -238,7 +243,7 @@ pub struct PinData {
     /// Pin number on data connector
     pub dlc_pin_number: u32,
     /// Pin ID
-    pub dlc_pin_type_id: u32
+    pub dlc_pin_type_id: u32,
 }
 
 #[repr(C)]
@@ -250,7 +255,7 @@ pub struct RscConflictItem {
     /// Number of entries in [RscConflictItem::p_rsc_conflict_data]
     pub num_entries: u32,
     /// Pointer to array of [RscConflictData]
-    pub p_rsc_conflict_data: *mut RscConflictData
+    pub p_rsc_conflict_data: *mut RscConflictData,
 }
 
 #[repr(C)]
@@ -260,7 +265,7 @@ pub struct RscConflictData {
     /// MVCI handle ID with conflict
     pub h_mod: u32,
     /// The conflicting resource ID
-    pub resource_id: u32
+    pub resource_id: u32,
 }
 
 #[repr(C)]
@@ -272,7 +277,7 @@ pub struct UniqueRespIdTableItem {
     /// Number of entries in [UniqueRespIdTableItem::p_unique_data]
     pub num_entries: u32,
     /// Pointer to array of [EcuUniqueRespData]
-    pub p_unique_data: *mut EcuUniqueRespData
+    pub p_unique_data: *mut EcuUniqueRespData,
 }
 
 #[repr(C)]
@@ -284,7 +289,7 @@ pub struct EcuUniqueRespData {
     /// Number of ComParams for the unique identifier
     pub num_param_items: u32,
     /// Pointer to array of ComParams used to uniquely define the ECUs unique response
-    pub p_params: *mut ParamItem
+    pub p_params: *mut ParamItem,
 }
 
 #[repr(C)]
@@ -300,7 +305,7 @@ pub struct EventItem {
     /// Timestamp in microseconds
     pub timestamp: u32,
     /// Pointer to the data of the event
-    pub p_data: *mut c_void
+    pub p_data: *mut c_void,
 }
 
 #[repr(C)]
@@ -310,7 +315,7 @@ pub struct InfoData {
     /// Information code
     pub info_code: PduInfo,
     /// optional extra information data
-    pub extra_info_data: u32
+    pub extra_info_data: u32,
 }
 
 #[repr(C)]
@@ -320,7 +325,7 @@ pub struct ErrorData {
     /// Error code
     pub error_code_id: PduErrorEvt,
     /// optional extra error information
-    pub extra_error_info_id: u32
+    pub extra_error_info_id: u32,
 }
 
 #[repr(C)]
@@ -344,7 +349,7 @@ pub struct ResultData {
     /// Number of bytes in [ResultData::p_data_bytes]
     pub num_data_bytes: u32,
     /// Pointer to payload data structure
-    pub p_data_bytes: *mut u8
+    pub p_data_bytes: *mut u8,
 }
 
 #[repr(C)]
@@ -358,7 +363,7 @@ pub struct ExtraInfo {
     /// Reference to response header bytes
     pub p_header_bytes: *mut u8,
     /// Reference to response footer bytes
-    pub p_footer_bytes: *mut u8
+    pub p_footer_bytes: *mut u8,
 }
 
 #[repr(C)]
@@ -368,7 +373,7 @@ pub struct FlagData {
     /// Number of bytes in [FlagData::p_flag_data]
     pub num_flag_bytes: u32,
     /// Pointer to flag bytes
-    pub p_flag_data: *mut u8
+    pub p_flag_data: *mut u8,
 }
 
 #[repr(C)]
@@ -402,7 +407,7 @@ pub struct VersionData {
     /// PDU API software version (Bit encoded)
     pub pdu_api_sw_version: u32,
     /// PDU API software date (Bit encoded)
-    pub pdu_api_sw_date: u32
+    pub pdu_api_sw_date: u32,
 }
 
 #[repr(C)]
@@ -422,17 +427,17 @@ pub struct CopCtrlData {
     /// Number of elements in [CopCtrlData::expected_response_array]
     pub num_possible_expected_responses: u32,
     /// Pointer to an array of expected responses
-    pub expected_response_array: *mut ExpRespData
+    pub expected_response_array: *mut ExpRespData,
 }
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 /// DoIP IO Entity address data
 pub struct IoEntityAddressData {
-    /// Logical addresses 
+    /// Logical addresses
     pub logical_address: u32,
     /// Timeout in milliseconds to wait for responses
-    pub doip_ctrl_timeout: u32
+    pub doip_ctrl_timeout: u32,
 }
 
 #[repr(C)]
@@ -446,7 +451,7 @@ pub struct IoEntityStatusData {
     /// Number of current sockets
     pub tcp_clients: u32,
     /// Optional limit in bytes for max size of a single DoIP request
-    pub max_data_size: u32
+    pub max_data_size: u32,
 }
 
 #[repr(C)]
@@ -466,7 +471,7 @@ pub struct ExpRespData {
     /// Number of items in [ExpRespData::p_unique_resp_ids]
     pub num_unique_resp_ids: u32,
     /// Array containing unique response IDs
-    pub p_unique_resp_ids: *mut u32
+    pub p_unique_resp_ids: *mut u32,
 }
 
 #[repr(C)]
@@ -478,7 +483,7 @@ pub struct ParamByteFieldData {
     /// Current (actual) number of bytes in [ParamByteFieldData::p_data_array]
     pub param_act_len: u32,
     /// Pointer to data array
-    pub p_data_array: *mut u8
+    pub p_data_array: *mut u8,
 }
 
 #[repr(C)]
@@ -492,7 +497,7 @@ pub struct ParamStructFieldData {
     /// Current (actual) number of structures in [ParamStructFieldData::p_struct_array]
     pub param_act_entries: u32,
     /// Pointer to structure array (See [ParamStructSessionTiming] and [ParamStructAccessTiming])
-    pub p_struct_array: *mut c_void
+    pub p_struct_array: *mut c_void,
 }
 
 #[repr(C)]
@@ -508,7 +513,7 @@ pub struct ParamStructSessionTiming {
     /// 10ms resolution
     pub p2_star_high: u8,
     /// 10ms resolution
-    pub p2_star_low: u8
+    pub p2_star_low: u8,
 }
 
 #[repr(C)]
@@ -526,7 +531,7 @@ pub struct ParamStructAccessTiming {
     /// 0.5ms resolution - Minimum inter-byte time for tester request
     pub p4_min: u8,
     /// Timing set type
-    pub timing_set: TimingSet
+    pub timing_set: TimingSet,
 }
 
 #[repr(C)]
@@ -538,5 +543,5 @@ pub struct ParamLongFieldData {
     /// Current (actual) number of entries in [ParamLongFieldData::p_data_array]
     pub param_act_len: u32,
     /// Pointer to data array
-    pub p_data_array: *mut u32
+    pub p_data_array: *mut u32,
 }


### PR DESCRIPTION
Closes #6.

- Enum representations have been corrected;
- Formal changes also;

The crate version has been updated to 0.9.1.